### PR TITLE
ci: build CI based on github action

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,88 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+      - "releases/**"
+
+
+name: Check
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.arch }}-unknown-linux-gnu
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: check
+          args: --all-features --target ${{ matrix.arch }}-unknown-linux-gnu
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          target: ${{ matrix.arch }}-unknown-linux-gnu
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          use-cross: true
+          command: clippy
+          args: --all-features --all-targets --target ${{ matrix.arch }}-unknown-linux-gnu -- -D warnings
+
+  deny:
+    name: Deny
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}
+        arguments: --all-features

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,49 @@
+name: UT
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: cargo, llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-cargo-dependencies
+        with:
+          path: |
+            ~/.cargo/.crates2.json
+            ~/.cargo/.crates.toml
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            ~/.cargo/bin/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+
+      - name: Test pika-proxy
+        run: cargo llvm-cov --all-features -p dbs-address-space --lcov --output-path pika-proxy.info
+      - name: Collection Coverage
+        run: cargo llvm-cov --no-run --lcov --output-path lcov.info
+
+      - name: Save coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: ./*.info
+          if-no-files-found: error


### PR DESCRIPTION
Build CI based on github actions. Include cargo build, cargo fmt, cargo clippy, cargo deny, UT.

Fixes: #8