### PR TITLE
refactor: use Path instead of str

### DIFF
--- a/src/proxy/config.rs
+++ b/src/proxy/config.rs
@@ -1,5 +1,7 @@
 use serde::{de, Deserialize, Deserializer, Serialize};
-use std::{fs::File, io::Read, time::Duration};
+use std::{fs::File, io::Read, path::Path, time::Duration};
+
+use crate::utils::error::Result as PikaProxyResult;
 
 const KB: u64 = 1024;
 const MB: u64 = 1024 * KB;
@@ -132,12 +134,12 @@ fn parse_string_to_num_and_unit(str: &str) -> (u64, &str) {
 }
 
 impl Config {
-    pub fn from_path(path: &str) -> Self {
-        let mut f = File::open(path).unwrap();
+    pub fn from_path<P: AsRef<Path>>(path: P) -> PikaProxyResult<Self> {
+        let mut f = File::open(path)?;
         let mut content = String::new();
-        f.read_to_string(&mut content).unwrap();
-        let config: Config = toml::from_str(&content).unwrap();
-        config
+        f.read_to_string(&mut content)?;
+        let config: Config = toml::from_str(&content)?;
+        Ok(config)
     }
 
     pub fn proxy_addr(&self) -> &str {
@@ -149,8 +151,9 @@ impl Config {
     }
 }
 
+#[cfg(test)]
 mod tests {
-    use crate::proxy::config::Config;
+    use super::Config;
 
     #[test]
     fn test_config() {
@@ -158,7 +161,8 @@ mod tests {
         let mut root_path = project_root::get_project_root().unwrap();
         root_path.push(path);
         let config_path = root_path.to_str().unwrap();
-        let config = Config::from_path(config_path);
-        println!("{:?}", config);
+        let config = Config::from_path(config_path).unwrap();
+        assert_eq!(config.admin_addr, "0.0.0.0:11080");
+        assert_eq!(config.proxy_addr, "127.0.0.1:19000")
     }
 }

--- a/src/proxy/config.rs
+++ b/src/proxy/config.rs
@@ -160,8 +160,7 @@ mod tests {
         let path = "config/proxy.toml";
         let mut root_path = project_root::get_project_root().unwrap();
         root_path.push(path);
-        let config_path = root_path.to_str().unwrap();
-        let config = Config::from_path(config_path).unwrap();
+        let config = Config::from_path(root_path).unwrap();
         assert_eq!(config.admin_addr, "0.0.0.0:11080");
         assert_eq!(config.proxy_addr, "127.0.0.1:19000")
     }

--- a/src/proxy/proxy.rs
+++ b/src/proxy/proxy.rs
@@ -32,8 +32,8 @@ pub(crate) struct ProxyOptions {
 }
 
 impl From<&ProxyOptions> for Proxy {
-    fn from(option: &ProxyOptions) -> Self {
-        let config = Config::from_path(&option.config_path);
+    fn from(option: &ProxyOptions) -> Proxy {
+        let config = Config::from_path(&option.config_path).unwrap();
         let proxy = RawProxy {
             xauth: String::new(),
 

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -9,7 +9,9 @@ pub enum PikaProxyError {
     #[error("can't not open file: {0}")]
     FailedOpenDB(String),
     #[error("IO error: {0}")]
-    Io(#[source] Box<io::Error>),
+    Io(#[from] io::Error),
+    #[error("Parsing error: {0}")]
+    ParseError(#[from] toml::de::Error),
     #[error("unexpected error: {0}")]
     UnexpectedError(String),
     #[error("key or value size is invalid")]


### PR DESCRIPTION
use Path trait in config parsing.

Fixes: #14 