### PR TITLE
refactor: split and optimize config type

### DIFF
--- a/config/proxy.toml
+++ b/config/proxy.toml
@@ -3,7 +3,7 @@
 #                  Codis-Proxy                   #
 #                                                #
 ##################################################
-
+[proxy]
 # Set Codis Product Name/Auth.
 product_name = "codis-demo"
 product_auth = ""
@@ -20,93 +20,82 @@ admin_addr = "0.0.0.0:11080"
 
 # Set bind address for proxy, proto_type can be "tcp", "tcp4", "tcp6", "unix" or "unixpacket".
 proto_type = "tcp4"
-proxy_addr = "127.0.0.1:19000"
+addr = "127.0.0.1:19000"
 
-# Set jodis address & session timeout
-#   1. jodis_name is short for jodis_coordinator_name, only accept "zookeeper" & "etcd".
-#   2. jodis_addr is short for jodis_coordinator_addr
-#   3. jodis_auth is short for jodis_coordinator_auth, for zookeeper/etcd, "user:password" is accepted.
-#   4. proxy will be registered as node:
-#        if jodis_compatible = true (not suggested):
-#          /zk/codis/db_{PRODUCT_NAME}/proxy-{HASHID} (compatible with Codis2.0)
-#        or else
-#          /jodis/{PRODUCT_NAME}/proxy-{HASHID}
-jodis_name = ""
-jodis_addr = ""
-jodis_auth = ""
-jodis_timeout = "20s"
-jodis_compatible = false
-
+protocol_type = "tcp4"
 # Set datacenter of proxy.
-proxy_datacenter = ""
+datacenter = ""
 
 # Set max number of alive sessions.
-proxy_max_clients = 1000
+max_clients = 1000
 
 # Set max offheap memory size. (0 to disable)
-proxy_max_offheap_size = "1024mb"
+max_offheap_size = "1024mb"
 
 # Set heap placeholder to reduce GC frequency.
-proxy_heap_placeholder = "256mb"
+heap_placeholder = "256mb"
 
+[backend]
 # Proxy will ping backend redis (and clear 'MASTERDOWN' state) in a predefined interval. (0 to disable)
-backend_ping_period = "5s"
+ping_period = "5s"
 
 # Set backend recv buffer size & timeout.
-backend_recv_bufsize = "128kb"
-backend_recv_timeout = "30s"
+recv_bufsize = "128kb"
+recv_timeout = "30s"
 
 # Set backend send buffer & timeout.
-backend_send_bufsize = "128kb"
-backend_send_timeout = "30s"
+send_bufsize = "128kb"
+send_timeout = "30s"
 
 # Set backend pipeline buffer size.
-backend_max_pipeline = 20480
+max_pipeline = 20480
 
 # Set backend never read replica groups, default is false
-backend_primary_only = false
+primary_only = false
 
 # Set backend parallel connections per server
-backend_primary_parallel = 1
-backend_replica_parallel = 1
+primary_parallel = 1
+replica_parallel = 1
 
 # Set backend tcp keepalive period. (0 to disable)
-backend_keepalive_period = "75s"
+keepalive_period = "75s"
 
 # Set number of databases of backend.
-backend_number_databases = 16
+number_databases = 16
 
+[session]
 # If there is no request from client for a long time, the connection will be closed. (0 to disable)
 # Set session recv buffer size & timeout.
-session_recv_bufsize = "128kb"
-session_recv_timeout = "30m"
+recv_bufsize = "128kb"
+recv_timeout = "30m"
 
 # Set session send buffer size & timeout.
-session_send_bufsize = "64kb"
-session_send_timeout = "30s"
+send_bufsize = "64kb"
+send_timeout = "30s"
 
 # Make sure this is higher than the max number of requests for each pipeline request, or your client may be blocked.
 # Set session pipeline buffer size.
-session_max_pipeline = 10000
+max_pipeline = 10000
 
 # Set session tcp keepalive period. (0 to disable)
-session_keepalive_period = "75s"
+keepalive_period = "75s"
 
 # Set session to be sensitive to failures. Default is false, instead of closing socket, proxy will send an error response to client.
-session_break_on_failure = false
+break_on_failure = false
 
+[metrics]
 # Set metrics server (such as http://localhost:28000), proxy will report json formatted metrics to specified server in a predefined period.
-metrics_report_server = ""
-metrics_report_period = "1s"
+report_server = ""
+report_period = "1s"
 
 # Set influxdb server (such as http://localhost:8086), proxy will report metrics to influxdb.
-metrics_report_influxdb_server = ""
-metrics_report_influxdb_period = "1s"
-metrics_report_influxdb_username = ""
-metrics_report_influxdb_password = ""
-metrics_report_influxdb_database = ""
+report_influxdb_server = ""
+report_influxdb_period = "1s"
+report_influxdb_username = ""
+report_influxdb_password = ""
+report_influxdb_database = ""
 
 # Set statsd server (such as localhost:8125), proxy will report metrics to statsd.
-metrics_report_statsd_server = ""
-metrics_report_statsd_period = "1s"
-metrics_report_statsd_prefix = ""
+report_statsd_server = ""
+report_statsd_period = "1s"
+report_statsd_prefix = ""

--- a/src/proxy/proxy.rs
+++ b/src/proxy/proxy.rs
@@ -40,8 +40,8 @@ impl Proxy {
             online: false,
             closed: false,
 
-            lproxy_addr: SocketAddr::from_str(&config.proxy_addr()).unwrap(),
-            ladmin_addr: SocketAddr::from_str(&config.admin_addr()).unwrap(),
+            lproxy_addr: SocketAddr::from_str(&config.proxy.addr).unwrap(),
+            ladmin_addr: SocketAddr::from_str(&config.proxy.admin_addr).unwrap(),
 
             config: Arc::new(config),
         };


### PR DESCRIPTION
split config type to session, proxy, jodis, backend and metrics.And change protocol_type to enum.